### PR TITLE
Add python version 3.12 and 3.13 to testing matrices

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Checkout Qadence
       uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ serve = "mkdocs serve --dev-addr localhost:8000"
 test = "mkdocs build --clean --strict"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["310", "311"]
+python = ["310", "311", "312", "313"]
 
 [tool.hatch.build.targets.sdist]
 exclude = [


### PR DESCRIPTION
After #6, the testing matrix of hatch should be updated to test against the newer versions 3.12 and 3.13